### PR TITLE
fixed material parsing for components with value

### DIFF
--- a/utils/convert.py
+++ b/utils/convert.py
@@ -63,7 +63,10 @@ def format_components(spell):
     m = comps.get("m")
     if m:
         parts.append("M*")
-        material_detail = strip_markup(str(m))
+        try:
+            material_detail = strip_markup(m['text'])
+        except (KeyError, TypeError):
+            material_detail = strip_markup(str(m))
     return ", ".join(parts) or "None", material_detail
 
 
@@ -225,6 +228,6 @@ def spell_to_markdown(spell) -> str:
 
     if material_detail:
         lines.append("")
-        lines.append(f"\\* {material_detail}")
+        lines.append(f"* {material_detail}")
 
     return "\n".join(lines).strip() + "\n"

--- a/utils/convert.py
+++ b/utils/convert.py
@@ -228,6 +228,6 @@ def spell_to_markdown(spell) -> str:
 
     if material_detail:
         lines.append("")
-        lines.append(f"* {material_detail}")
+        lines.append(f"\\* {material_detail}")
 
     return "\n".join(lines).strip() + "\n"


### PR DESCRIPTION
makes components with values parsing include only the text and not additional fields.

i.e. for revivify components now properly displays
`* a diamond worth 300+ GP, which the spell consumes`
rather than
`\* {'text': 'a diamond worth 300+ GP, which the spell consumes', 'cost': 30000, 'consume': True}`  